### PR TITLE
fixed crash due to wrong allocation in new_stringobj_dedup

### DIFF
--- a/generic/main.c
+++ b/generic/main.c
@@ -163,7 +163,7 @@ static void age_cache(struct interp_cx* l) //{{{
 //}}}
 Tcl_Obj* new_stringobj_dedup(struct interp_cx* l, const char* bytes, int length) //{{{
 {
-	char				buf[STRING_DEDUP_MAX];
+	char				buf[STRING_DEDUP_MAX + 1];
 	const char			*keyname;
 	int					is_new;
 	struct kc_entry*	kce;


### PR DESCRIPTION
Hello,

I got a crash in this function mentioned above, when the length was exactly 16. In that case the NULL assignment in line 200 fails, obviously because it accesses memory which is out of range.
Allocating a buf of length STRING_DEDUP_MAX+1 fixes the problem.

Best Regards