### PR TITLE
fixed crash when run in slave interp, due to NULL clientData during c…

### DIFF
--- a/generic/main.c
+++ b/generic/main.c
@@ -2727,7 +2727,7 @@ int Rl_json_Init(Tcl_Interp* interp) //{{{
 
 	Tcl_SetAssocData(interp, "rl_json", NULL, l);
 
-	Tcl_NRCreateCommand(interp, "::rl_json::json", jsonObjCmd, jsonNRObjCmd, NULL, free_interp_cx);
+	Tcl_NRCreateCommand(interp, "::rl_json::json", jsonObjCmd, jsonNRObjCmd, l, free_interp_cx);
 	TEST_OK(Tcl_EvalEx(interp, "namespace eval ::rl_json {namespace export *}", -1, TCL_EVAL_DIRECT | TCL_EVAL_GLOBAL));
 
 	TEST_OK(Tcl_PkgProvide(interp, PACKAGE_NAME, PACKAGE_VERSION));


### PR DESCRIPTION
There is a crash when rl_json is used in a slave interp and the interp is [exit]ed. Because then the cleanup procedure is run and gets a NULL clientData as argument. The issue is fixed by this change.