### PR TITLE
Nmake builds

### DIFF
--- a/generic/api.c
+++ b/generic/api.c
@@ -257,7 +257,7 @@ int JSON_JArrayObjAppendList(Tcl_Interp* interp, Tcl_Obj* arrayObj, Tcl_Obj* ele
 }
 
 //}}}
-int JSON_SetJArrayObj(Tcl_Interp* interp, Tcl_Obj* obj, const int objc, Tcl_Obj* objv[]) //{{{
+int JSON_SetJArrayObj(Tcl_Interp* interp, Tcl_Obj* obj, int objc, Tcl_Obj* objv[]) //{{{
 {
 	enum json_types	type;
 	Tcl_ObjIntRep*	ir = NULL;

--- a/generic/json_types.c
+++ b/generic/json_types.c
@@ -460,7 +460,7 @@ static int set_from_any(Tcl_Interp* interp, Tcl_Obj* obj, Tcl_ObjType** objtype,
 	int						len;
 	struct parse_context	cx[CX_STACK_SIZE];
 	enum extensions			extensions = EXT_COMMENTS;
-	struct parse_error		details = {};
+	struct parse_error		details = {0};
 
 	if (interp)
 		l = Tcl_GetAssocData(interp, "rl_json", NULL);
@@ -475,7 +475,7 @@ static int set_from_any(Tcl_Interp* interp, Tcl_Obj* obj, Tcl_ObjType** objtype,
 				(l->typeBignum && Tcl_FetchIntRep(obj, l->typeBignum) != NULL)
 			)
 		) {
-			Tcl_ObjIntRep			ir = {.twoPtrValue = {}};
+			Tcl_ObjIntRep			ir = {.twoPtrValue = {0}};
 
 			// Must dup because obj will soon be us, creating a circular ref
 			replace_tclobj((Tcl_Obj**)&ir.twoPtrValue.ptr1, Tcl_DuplicateObj(obj));
@@ -682,7 +682,7 @@ after_value:	// Yeah, goto.  But the alternative abusing loops was worse
 	{
 		Tcl_ObjType*	top_objtype = g_objtype_for_type[cx[0].container];
 		Tcl_ObjIntRep*	top_ir = Tcl_FetchIntRep(cx[0].val, top_objtype);
-		Tcl_ObjIntRep	ir = {.twoPtrValue = {}};
+		Tcl_ObjIntRep	ir = {.twoPtrValue = {0}};
 
 		if (unlikely(top_ir == NULL))
 			Tcl_Panic("Can't get intrep for the top container");

--- a/generic/parser.c
+++ b/generic/parser.c
@@ -20,7 +20,7 @@ void throw_parse_error(Tcl_Interp* interp, struct parse_error* details) //{{{
 {
 	char		char_ofs_buf[20];		// 20 bytes allows for 19 bytes of decimal max 64 bit size_t, plus null terminator
 
-	snprintf(char_ofs_buf, 20, "%ld", details->char_ofs);
+	snprintf(char_ofs_buf, 20, "%zd", details->char_ofs);
 
 	Tcl_SetObjResult(interp, Tcl_ObjPrintf("Error parsing JSON value: %s at offset %ld", details->errmsg, details->char_ofs));
 	Tcl_SetErrorCode(interp, "RL", "JSON", "PARSE", details->errmsg, details->doc, char_ofs_buf, NULL);
@@ -283,12 +283,12 @@ int value_type(struct interp_cx* l, const unsigned char* doc, const unsigned cha
 					len = p-chunk;
 
 					if (likely(out == NULL)) {
-						replace_tclobj(&out, get_string(l, (const char*)chunk, len));
+                                            replace_tclobj(&out, get_string(l, (const char*)chunk, (int) len));
 					} else if (len > 0) {
 						if (unlikely(Tcl_IsShared(out)))
 							replace_tclobj(&out, Tcl_DuplicateObj(out));
 
-						Tcl_AppendToObj(out, (const char*)chunk, len);
+						Tcl_AppendToObj(out, (const char*)chunk, (int) len);
 					}
 
 					if (likely(*p == '"')) {
@@ -458,7 +458,7 @@ append_mapped:				Tcl_AppendToObj(out, &mapped, 1);		// Weird, but arranged this
 
 				*type = JSON_NUMBER;
 				if (val)
-					replace_tclobj(val, get_string(l, (const char*)start, p-start));
+                                    replace_tclobj(val, get_string(l, (const char*)start, (int)(p-start)));
 			}
 	}
 

--- a/generic/rl_json.c
+++ b/generic/rl_json.c
@@ -3012,7 +3012,7 @@ static int jsonValid(ClientData cdata, Tcl_Interp* interp, int objc, Tcl_Obj *co
 {
 	struct interp_cx*	l = (struct interp_cx*)cdata;
 	int					i, valid, retval=TCL_OK;
-	struct parse_error	details = {};
+	struct parse_error	details = {0};
 	Tcl_Obj*			detailsvar = NULL;
 	enum extensions	extensions = EXT_COMMENTS;		// By default, use the default set of extensions we accept
 	static const char *options[] = {
@@ -3511,6 +3511,7 @@ void free_interp_cx(ClientData cdata, Tcl_Interp* interp) //{{{
 }
 
 //}}}
+#ifndef _MSC_VER
 static int checkmem(ClientData cdata, Tcl_Interp* interp, int objc, Tcl_Obj *const objv[]) //{{{
 {
 	int					retcode = TCL_OK;
@@ -3601,6 +3602,7 @@ finally:
 }
 
 //}}}
+#endif // _MSC_VER
 
 #ifdef __cplusplus
 extern "C" {
@@ -3859,7 +3861,9 @@ DLLEXPORT int Rl_json_Init(Tcl_Interp* interp) //{{{
 		Tcl_NRCreateCommand(interp, "::rl_json::json", jsonObj, jsonNRObj, l, NULL);
 #endif
 
+#ifndef _MSC_VER
 		Tcl_CreateObjCommand(interp, NS "::checkmem", checkmem, l, NULL);
+#endif
 	}
 
 	TEST_OK(Tcl_PkgProvide(interp, PACKAGE_NAME, PACKAGE_VERSION));

--- a/generic/rl_json.c
+++ b/generic/rl_json.c
@@ -263,7 +263,7 @@ static void append_json_string(const struct serialize_context* scx, Tcl_Obj* obj
 	while (p < e) {
 		adv = Tcl_UtfToUniChar(p, &c);
 		if (unlikely(c <= 0x1f || c == '\\' || c == '"')) {
-			Tcl_DStringAppend(ds, chunk, p-chunk);
+			Tcl_DStringAppend(ds, chunk, (int) (p-chunk));
 			switch (c) {
 				case '"':	Tcl_DStringAppend(ds, "\\\"", 2); break;
 				case '\\':	Tcl_DStringAppend(ds, "\\\\", 2); break;
@@ -286,7 +286,7 @@ static void append_json_string(const struct serialize_context* scx, Tcl_Obj* obj
 	}
 
 	if (likely(p > chunk))
-		Tcl_DStringAppend(ds, chunk, p-chunk);
+		Tcl_DStringAppend(ds, chunk, (int) (p-chunk));
 
 	Tcl_DStringAppend(ds, "\"", 1);
 }
@@ -965,7 +965,8 @@ end:
 //}}}
 static void foreach_state_free(struct foreach_state* state) //{{{
 {
-	unsigned int i, j;
+	unsigned int i;
+    int j;
 
 	release_tclobj(&state->script);
 
@@ -992,7 +993,8 @@ static void foreach_state_free(struct foreach_state* state) //{{{
 static int NRforeach_next_loop_top(Tcl_Interp* interp, struct foreach_state* state) //{{{
 {
 	struct interp_cx* l = Tcl_GetAssocData(interp, "rl_json", NULL);
-	unsigned int j, k;
+	unsigned int j;
+    int k;
 
 	//fprintf(stderr, "Starting iteration %d/%d\n", i, max_loops);
 	// Set the iterator variables
@@ -1246,7 +1248,7 @@ static int foreach(Tcl_Interp* interp, int objc, Tcl_Obj *const objv[], enum col
 				THROW_ERROR_LABEL(done, retcode, "Cannot iterate over JSON type ", type_names[type]);
 		}
 
-		if (loops > state->max_loops)
+		if (loops > (int) state->max_loops)
 			state->max_loops = loops;
 	}
 
@@ -3099,7 +3101,7 @@ static int jsonValid(ClientData cdata, Tcl_Interp* interp, int objc, Tcl_Obj *co
 		TEST_OK_LABEL(finally, retval, Tcl_DictObjPut(interp, details_obj, k, v));
 
 		replace_tclobj(&k, get_string(l, "char_ofs", 8));
-		replace_tclobj(&v, Tcl_NewIntObj(details.char_ofs));
+		replace_tclobj(&v, Tcl_NewWideIntObj(details.char_ofs));
 		TEST_OK_LABEL(finally, retval, Tcl_DictObjPut(interp, details_obj, k, v));
 
 		if (NULL == Tcl_ObjSetVar2(interp, detailsvar, NULL, details_obj, TCL_LEAVE_ERR_MSG))

--- a/generic/rl_jsonInt.h
+++ b/generic/rl_jsonInt.h
@@ -9,7 +9,9 @@
 #include <math.h>
 #include <stddef.h>
 #include <stdint.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include <tclTomMath.h>
 #include "tip445.h"
 

--- a/win/makefile.vc
+++ b/win/makefile.vc
@@ -28,6 +28,9 @@ PRJ_OBJS = \
 PRJ_STUBOBJS = $(TMP_DIR)\rl_jsonStubLib.obj
 
 PRJ_DEFINES = -D_CRT_SECURE_NO_WARNINGS
+!if ($(TCL_MAJOR_VERSION) < 8) || ($(TCL_MAJOR_VERSION) == 8 && $(TCL_MINOR_VERSION) <= 6)
+PRJ_DEFINES = $(PRJ_DEFINES) -DTIP445_SHIM
+!endif
 
 !include "$(_RULESDIR)\targets.vc"
 


### PR DESCRIPTION
Fixes broken nmake builds wrt TIP445 as well as some VC++ issues. Passes all tests except failures in memory.test due to an inability to measure memory usage on Windows. In addition to build issues, have also modified C code for the following reasons:

- VC++ does not accept {} as struct init - replaced with {0}
- Fixed size_t -> int warnings with explicit casts
- Changed %ld for printf with %zd for size_t arguments
- Changed unsigned int to int in iterators to fix "signed/unsigned" warnings

Confirmed builds and passes tests with gcc on Ubuntu as well, except for memory-2.1 which was failing already (missing foreach_data directory)