### PR TITLE
Updates for Tcl 9 and ensemble fixes.

### DIFF
--- a/generic/api.c
+++ b/generic/api.c
@@ -306,13 +306,17 @@ int JSON_JArrayObjGetElements(Tcl_Interp* interp, Tcl_Obj* arrayObj, int* objc, 
 {
 	enum json_types	type;
 	Tcl_Obj*		val = NULL;
+    Tcl_Size		count;
 
 	TEST_OK(JSON_GetJvalFromObj(interp, arrayObj, &type, &val));
 	if (type != JSON_ARRAY) {
 		Tcl_SetObjResult(interp, Tcl_ObjPrintf("Expecting a JSON array, but got a JSON %s", get_type_name(type)));
 		return TCL_ERROR;
 	}
-	TEST_OK(Tcl_ListObjGetElements(interp, val, objc, objv));
+	TEST_OK(Tcl_ListObjGetElements(interp, val, &count, objv));
+	if (objc != NULL) {
+		*objc = count;
+	}
 
 	return TCL_OK;
 }
@@ -392,7 +396,7 @@ int JSON_Extract(Tcl_Interp* interp, Tcl_Obj* obj, Tcl_Obj* path, Tcl_Obj** res)
 	Tcl_Obj*	target = NULL;
 	Tcl_Obj**	pathv = NULL;
 	Tcl_Obj*	def = NULL;
-	int			pathc = 0;
+	Tcl_Size	pathc = 0;
 
 	if (path)
 		TEST_OK_LABEL(finally, code, Tcl_ListObjGetElements(interp, path, &pathc, &pathv));
@@ -418,7 +422,7 @@ int JSON_Exists(Tcl_Interp* interp, Tcl_Obj* obj, Tcl_Obj* path, int* exists) //
 {
 	Tcl_Obj*			target = NULL;
 	Tcl_Obj**			pathv = NULL;
-	int					pathc = 0;
+	Tcl_Size			pathc = 0;
 
 	if (path)
 		TEST_OK(Tcl_ListObjGetElements(interp, path, &pathc, &pathv));
@@ -451,7 +455,7 @@ int JSON_Set(Tcl_Interp* interp, Tcl_Obj* obj, Tcl_Obj *path, Tcl_Obj* replaceme
 	Tcl_Obj*			newval;
 	Tcl_Obj*			rep = NULL;
 	Tcl_Obj**			pathv = NULL;
-	int					pathc = 0;
+	Tcl_Size			pathc = 0;
 
 	if (Tcl_IsShared(obj))
 		THROW_ERROR_LABEL(finally, code, "JSON_Set called with shared object");
@@ -498,7 +502,8 @@ int JSON_Set(Tcl_Interp* interp, Tcl_Obj* obj, Tcl_Obj *path, Tcl_Obj* replaceme
 				//}}}
 			case JSON_ARRAY: //{{{
 				{
-					int			ac, index_str_len, ok=1;
+					Tcl_Size	ac, index_str_len;
+					int			ok=1;
 					long		index;
 					const char*	index_str;
 					char*		end;
@@ -658,7 +663,7 @@ int JSON_Unset(Tcl_Interp* interp, Tcl_Obj* obj, Tcl_Obj *path) //{{{
 	Tcl_Obj*		step = NULL;
 	Tcl_Obj*		src = NULL;
 	Tcl_Obj*		target = NULL;
-	int				pathc = 0;
+	Tcl_Size		pathc = 0;
 	Tcl_Obj**		pathv = NULL;
 	int				retval = TCL_OK;
 
@@ -711,7 +716,8 @@ int JSON_Unset(Tcl_Interp* interp, Tcl_Obj* obj, Tcl_Obj *path) //{{{
 				//}}}
 			case JSON_ARRAY: //{{{
 				{
-					int			ac, index_str_len, ok=1;
+					Tcl_Size	ac, index_str_len;
+					int			ok=1;
 					long		index;
 					const char*	index_str;
 					char*		end;
@@ -809,7 +815,8 @@ int JSON_Unset(Tcl_Interp* interp, Tcl_Obj* obj, Tcl_Obj *path) //{{{
 			//}}}
 		case JSON_ARRAY: //{{{
 			{
-				int			ac, index_str_len, ok=1;
+				Tcl_Size	ac, index_str_len;
+				int			ok=1;
 				long		index;
 				const char*	index_str;
 				char*		end;
@@ -1030,15 +1037,21 @@ int JSON_Length(Tcl_Interp* interp, Tcl_Obj* obj, Tcl_Obj* path, int* length) //
 	int				retval = TCL_OK;
 	Tcl_Obj*		val = NULL;
 	Tcl_Obj*		target = NULL;
+	Tcl_Size		len;
 
 	TEST_OK_LABEL(finally, retval, JSON_Extract(interp, obj, path, &target));
 
 	TEST_OK_LABEL(finally, retval, JSON_GetJvalFromObj(interp, target, &type, &val));
 
 	switch (type) {
-		case JSON_ARRAY:  retval = Tcl_ListObjLength(interp, val, length); break;
-		case JSON_OBJECT: retval = Tcl_DictObjSize(interp, val, length);   break;
-
+		case JSON_ARRAY:
+			retval = Tcl_ListObjLength(interp, val, &len);
+			if (length != NULL) *length = len;
+			break;
+		case JSON_OBJECT:
+			retval = Tcl_DictObjSize(interp, val, &len);
+			if (length != NULL) *length = len;
+			break;
 		case JSON_DYN_STRING:
 		case JSON_DYN_NUMBER:
 		case JSON_DYN_BOOL:
@@ -1126,7 +1139,7 @@ int JSON_Foreach(Tcl_Interp* interp, Tcl_Obj* iterators, JSON_ForeachBody* body,
 	unsigned int			i;
 	int						retcode=TCL_OK;
 	struct foreach_state*	state = NULL;
-	int						objc;
+	Tcl_Size				objc;
 	Tcl_Obj**				objv = NULL;
 	Tcl_Obj*				it_res = NULL;
 	struct interp_cx*		l = Tcl_GetAssocData(interp, "rl_json", NULL);
@@ -1173,14 +1186,16 @@ int JSON_Foreach(Tcl_Interp* interp, Tcl_Obj* iterators, JSON_ForeachBody* body,
 	}
 
 	for (i=0; i<state->iterators; i++) {
-		int				loops, j;
+		Tcl_Size		loops, count;
+		int				j;
 		enum json_types	type;
 		Tcl_Obj*		val = NULL;
 		Tcl_Obj*		varlist = objv[i*2];
 
 		replace_tclobj(&state->it[i].varlist, varlist);
 
-		TEST_OK_LABEL(done, retcode, Tcl_ListObjGetElements(interp, state->it[i].varlist, &state->it[i].var_c, &state->it[i].var_v));
+		TEST_OK_LABEL(done, retcode, Tcl_ListObjGetElements(interp, state->it[i].varlist, &count, &state->it[i].var_v));
+		state->it[i].var_c = count;
 		for (j=0; j < state->it[i].var_c; j++)
 			Tcl_IncrRefCount(state->it[i].var_v[j]);
 
@@ -1191,7 +1206,8 @@ int JSON_Foreach(Tcl_Interp* interp, Tcl_Obj* iterators, JSON_ForeachBody* body,
 		switch (type) {
 			case JSON_ARRAY:
 				TEST_OK_LABEL(done, retcode,
-						Tcl_ListObjGetElements(interp, val, &state->it[i].data_c, &state->it[i].data_v));
+						Tcl_ListObjGetElements(interp, val, &count, &state->it[i].data_v));
+				state->it[i].data_c = count;
 				state->it[i].data_i = 0;
 				state->it[i].is_array = 1;
 				loops = (int)ceil(state->it[i].data_c / (double)state->it[i].var_c);
@@ -1318,7 +1334,8 @@ cleanup_search:
 											break;
 											//}}}
 										} else { // Iterate over it_res as a list {{{
-											int			oc, i;
+											Tcl_Size	oc;
+											int			i;
 											Tcl_Obj**	ov = NULL;
 
 											TEST_OK_LABEL(done, retcode, Tcl_ListObjGetElements(interp, it_res, &oc, &ov));
@@ -1385,7 +1402,7 @@ int JSON_Valid(Tcl_Interp* interp, Tcl_Obj* json, int* valid, enum extensions ex
 	const unsigned char*	p;
 	const unsigned char*	e;
 	const unsigned char*	val_start;
-	int						len;
+	Tcl_Size				len;
 	struct parse_context	cx[CX_STACK_SIZE];
 
 	if (interp)

--- a/generic/cbor.c
+++ b/generic/cbor.c
@@ -1,4 +1,5 @@
 #include "rl_jsonInt.h"
+#include <limits.h>
 
 enum svalue_types {
 	S_FALSE = 20,
@@ -519,7 +520,7 @@ static int cbor_match_map(Tcl_Interp* interp, uint8_t ai, uint64_t val, const ui
 	Tcl_Obj*		cbor_val = NULL;
 	Tcl_HashTable	remaining;
 	const uint8_t*	p = *pPtr;
-	int				size;
+	Tcl_Size		size;
 	int				skipping = 0;
 
 	Tcl_InitHashTable(&remaining, TCL_ONE_WORD_KEYS);
@@ -709,7 +710,7 @@ data_item: // loop: read off tags
 		//}}}
 		case M_BSTR: // Compare as byte strings {{{
 		{
-			size_t				pathlen;
+			Tcl_Size			pathlen;
 			const uint8_t*		pathval = (const uint8_t*)Tcl_GetBytesFromObj(interp, pathElem, &pathlen);
 			const uint8_t*const	pathend = pathval + pathlen;
 			const uint8_t*const	pe = p + val;
@@ -768,7 +769,7 @@ data_item: // loop: read off tags
 		//}}}
 		case M_UTF8: // Compare as UTF-8 strings {{{
 		{
-			int					s_pathlen;
+			Tcl_Size			s_pathlen;
 			const uint8_t*		s_pathval = (const uint8_t*)Tcl_GetStringFromObj(pathElem, &s_pathlen);
 			const uint8_t*const	s_pathend = s_pathval + s_pathlen;
 			const uint8_t*const	s_pe = p + val;
@@ -837,7 +838,7 @@ data_item: // loop: read off tags
 		//}}}
 		case M_ARR:  // Compare as a list {{{
 		{
-			int			oc;
+			Tcl_Size	oc;
 			Tcl_Obj**	ov;
 			if (TCL_OK != Tcl_ListObjGetElements(NULL, pathElem, &oc, &ov)) {
 				// Skip remaining elements {{{
@@ -919,7 +920,7 @@ data_item: // loop: read off tags
 				}
 				case 22: case 23:	// Simple value: null / undefined - treat zero length string as matching
 				{
-					int len;
+					Tcl_Size len;
 					Tcl_GetStringFromObj(pathElem, &len);
 					if (len == 0) goto matches;
 					goto mismatch;
@@ -959,9 +960,9 @@ int CBOR_GetDataItemFromPath(Tcl_Interp* interp, Tcl_Obj* cborObj, Tcl_Obj* path
 {
 	int						code = TCL_OK;
 	Tcl_Obj**				pathv = NULL;
-	int						pathc = 0;
+	Tcl_Size				pathc = 0;
 	const uint8_t*			p = NULL;
-	size_t					byteslen = 0;
+	Tcl_Size				byteslen = 0;
 	const uint8_t*			bytes = NULL;
 	const uint8_t**			circular = g_circular_buf;
 
@@ -1253,7 +1254,7 @@ static int cbor_nr_cmd(ClientData cdata, Tcl_Interp* interp, int objc, Tcl_Obj*c
 			enum {A_cmd=A_OP, A_BYTES, A_objc};
 			CHECK_ARGS_LABEL(finally, code, "bytes");
 
-			int				len;
+			Tcl_Size		len;
 			const uint8_t*	bytes = Tcl_GetByteArrayFromObj(objv[A_BYTES], &len);
 			const uint8_t*	p = bytes;
 

--- a/generic/json_types.c
+++ b/generic/json_types.c
@@ -298,7 +298,7 @@ int JSON_SetIntRep(Tcl_Obj* target, enum json_types type, Tcl_Obj* replacement) 
 	replace_tclobj(&rep, replacement);
 
 	if (type == JSON_STRING && rep) { // Check for template values
-		int					len;
+		Tcl_Size			len;
 		const char*			str = Tcl_GetStringFromObj(replacement, &len);
 		const char*const	strend = str + len;
 		enum json_types		template_type;
@@ -412,7 +412,7 @@ static void dup_internal_rep(Tcl_Obj* src, Tcl_Obj* dest, Tcl_ObjType* objtype) 
 		Tcl_Panic("dup_internal_rep asked to duplicate for type, but that type wasn't available on the src object");
 
 	if (src == srcir->twoPtrValue.ptr1) {
-		int			len;
+		Tcl_Size	len;
 		const char*	str = Tcl_GetStringFromObj((Tcl_Obj*)srcir->twoPtrValue.ptr1, &len);
 		// Don't know how this happens yet, but it's bad news - we get into an endless recursion of duplicateobj calls until the stack blows up
 
@@ -421,7 +421,7 @@ static void dup_internal_rep(Tcl_Obj* src, Tcl_Obj* dest, Tcl_ObjType* objtype) 
 	} else {
 		if (objtype == &json_array) {
 			Tcl_Obj**	ov = NULL;
-			int			oc;
+			Tcl_Size	oc;
 			// The list type's internal structure sharing on duplicates messes up our sharing,
 			// rather recreate a fresh list referencing the original element objects instead
 			if (TCL_OK != Tcl_ListObjGetElements(NULL, srcir->twoPtrValue.ptr1, &oc, &ov))
@@ -491,7 +491,7 @@ static void update_string_rep_number(Tcl_Obj* obj) //{{{
 {
 	Tcl_ObjInternalRep*	ir = Tcl_FetchInternalRep(obj, &json_number);
 	const char*			str;
-	int					len;
+	Tcl_Size			len;
 
 	if (ir->twoPtrValue.ptr1 == obj)
 		Tcl_Panic("Turtles all the way down!");
@@ -565,7 +565,7 @@ static int set_from_any(Tcl_Interp* interp, Tcl_Obj* obj, Tcl_ObjType** objtype,
 	const unsigned char*	p;
 	const unsigned char*	e;
 	const unsigned char*	val_start;
-	int						len;
+	Tcl_Size				len;
 	struct parse_context	cx[CX_STACK_SIZE];
 	enum extensions			extensions = EXT_COMMENTS;
 	struct parse_error		details = {0};

--- a/generic/rl_json.c
+++ b/generic/rl_json.c
@@ -3596,6 +3596,7 @@ collect_interp_result:
 }
 
 //}}}
+#if !ENSEMBLE
 static int jsonNRObj(ClientData cdata, Tcl_Interp* interp, int objc, Tcl_Obj *const objv[]) //{{{
 {
 	int subcommand;
@@ -3781,6 +3782,7 @@ static int jsonObj(ClientData cdata, Tcl_Interp* interp, int objc, Tcl_Obj *cons
 }
 
 //}}}
+#endif
 
 void free_interp_cx(ClientData cdata, Tcl_Interp* interp) //{{{
 {

--- a/generic/rl_json.c
+++ b/generic/rl_json.c
@@ -4106,7 +4106,7 @@ DLLEXPORT int Rl_json_Init(Tcl_Interp* interp) //{{{
 			Tcl_ListObjAppendElement(NULL, subcommands, Tcl_NewStringObj("decode",     -1));
 			Tcl_ListObjAppendElement(NULL, subcommands, Tcl_NewStringObj("isnull",     -1));
 			Tcl_ListObjAppendElement(NULL, subcommands, Tcl_NewStringObj("template",   -1));
-			Tcl_ListObjAppendElement(NULL, subcommands, Tcl_NewStringObj("_template",  -1));
+			Tcl_ListObjAppendElement(NULL, subcommands, Tcl_NewStringObj("template_string", -1));
 			Tcl_ListObjAppendElement(NULL, subcommands, Tcl_NewStringObj("foreach",    -1));
 			Tcl_ListObjAppendElement(NULL, subcommands, Tcl_NewStringObj("lmap",       -1));
 			Tcl_ListObjAppendElement(NULL, subcommands, Tcl_NewStringObj("amap",       -1));

--- a/generic/rl_json.c
+++ b/generic/rl_json.c
@@ -1,5 +1,9 @@
 #include "rl_jsonInt.h"
 
+#ifndef TCL_SIZE_MODIFIER
+#define TCL_SIZE_MODIFIER ""
+#endif
+
 TCL_DECLARE_MUTEX(g_config_mutex);
 Tcl_Obj*		g_packagedir = NULL;
 Tcl_Obj*		g_includedir = NULL;
@@ -237,7 +241,8 @@ display *obj
 
 			if (Tcl_HasStringRep(obj)) { // Has a string rep already, make sure it's not hex or octal, and not padded with whitespace
 				const char* s;
-				int			len, start=0;
+				Tcl_Size	len;
+				int			start=0;
 
 				s = Tcl_GetStringFromObj(obj, &len);
 				if (len >= 1 && s[0] == '-')
@@ -316,7 +321,7 @@ display *obj
 //}}}
 static void append_json_string(const struct serialize_context* scx, Tcl_Obj* obj) //{{{
 {
-	int				len;
+	Tcl_Size		len;
 	const char*		chunk;
 	const char*		p;
 	const char*		e;
@@ -394,7 +399,8 @@ static int serialize_json_val(Tcl_Interp* interp, struct serialize_context* scx,
 					// Have to do the template subst here rather than at
 					// parse time since the dict keys would be broken otherwise
 					if (scx->serialize_mode == SERIALIZE_TEMPLATE) {
-						int			len, stype;
+						Tcl_Size	len;
+						int			stype;
 						const char*	s;
 
 						s = Tcl_GetStringFromObj(k, &len);
@@ -451,7 +457,8 @@ static int serialize_json_val(Tcl_Interp* interp, struct serialize_context* scx,
 			//}}}
 		case JSON_ARRAY: //{{{
 			{
-				int				i, oc, first=1;
+				int				i, first=1;
+				Tcl_Size		oc;
 				Tcl_Obj**		ov;
 				Tcl_Obj*		iv = NULL;
 				enum json_types	v_type = JSON_UNDEF;
@@ -475,7 +482,7 @@ static int serialize_json_val(Tcl_Interp* interp, struct serialize_context* scx,
 		case JSON_NUMBER: //{{{
 			{
 				const char*	bytes;
-				int			len;
+				Tcl_Size	len;
 
 				bytes = Tcl_GetStringFromObj(val, &len);
 				Tcl_DStringAppend(ds, bytes, len);
@@ -645,7 +652,7 @@ int serialize(Tcl_Interp* interp, struct serialize_context* scx, Tcl_Obj* obj) /
 static int get_modifier(Tcl_Interp* interp, Tcl_Obj* modobj, enum modifiers* modifier) //{{{
 {
 	// This must be kept in sync with the modifiers enum
-	static CONST char *modstrings[] = {
+	static const char *modstrings[] = {
 		"",
 		"?length",
 		"?size",
@@ -664,7 +671,8 @@ static int get_modifier(Tcl_Interp* interp, Tcl_Obj* modobj, enum modifiers* mod
 //}}}
 int resolve_path(Tcl_Interp* interp, Tcl_Obj* src, Tcl_Obj *const pathv[], int pathc, Tcl_Obj** target, const int exists, const int modifiers, Tcl_Obj* def) //{{{
 {
-	int					i, modstrlen;
+	int					i;
+	Tcl_Size			modstrlen;
 	enum json_types		type;
 	struct interp_cx*	l = Tcl_GetAssocData(interp, "rl_json", NULL);
 	const char*			modstr;
@@ -715,7 +723,7 @@ int resolve_path(Tcl_Interp* interp, Tcl_Obj* src, Tcl_Obj *const pathv[], int p
 							switch (type) {
 								case JSON_ARRAY:
 									{
-										int			ac;
+										Tcl_Size	ac;
 										Tcl_Obj**	av;
 										TEST_OK_LABEL(done, retval, Tcl_ListObjGetElements(interp, val, &ac, &av));
 										EXISTS(1);
@@ -747,7 +755,7 @@ int resolve_path(Tcl_Interp* interp, Tcl_Obj* src, Tcl_Obj *const pathv[], int p
 								THROW_ERROR_LABEL(done, retval, Tcl_GetString(step), " modifier is not supported for type ", type_names[type]);
 							}
 							{
-								int	size;
+								Tcl_Size	size;
 								TEST_OK_LABEL(done, retval, Tcl_DictObjSize(interp, val, &size));
 								EXISTS(1);
 								replace_tclobj(&t, Tcl_NewIntObj(size));
@@ -820,7 +828,8 @@ int resolve_path(Tcl_Interp* interp, Tcl_Obj* src, Tcl_Obj *const pathv[], int p
 				//}}}
 			case JSON_ARRAY: //{{{
 				{
-					int			ac, index_str_len, ok=1;
+					Tcl_Size	ac, index_str_len;
+					int			ok=1;
 					long		index;
 					const char*	index_str;
 					char*		end;
@@ -956,7 +965,8 @@ int convert_to_tcl(Tcl_Interp* interp, Tcl_Obj* obj, Tcl_Obj** out) //{{{
 
 		case JSON_ARRAY:
 			{
-				int			i, oc;
+				int			i;
+				Tcl_Size	oc;
 				Tcl_Obj**	ov = NULL;
 				Tcl_Obj*	elem = NULL;
 				Tcl_Obj*	new = NULL;
@@ -1007,7 +1017,8 @@ int convert_to_tcl(Tcl_Interp* interp, Tcl_Obj* obj, Tcl_Obj** out) //{{{
 //}}}
 static int _new_object(Tcl_Interp* interp, int objc, Tcl_Obj *const objv[], Tcl_Obj** res) //{{{
 {
-	int			i, ac, retval=TCL_OK;
+	int			i, retval=TCL_OK;
+	Tcl_Size	ac;
 	Tcl_Obj**	av = NULL;
 	Tcl_Obj*	new_val = NULL;
 	Tcl_Obj*	val = NULL;
@@ -1165,7 +1176,8 @@ cleanup_search:
 									break;
 									//}}}
 								} else { // Iterate over it_res as a list {{{
-									int			oc, i;
+									Tcl_Size	oc;
+									int			i;
 									Tcl_Obj**	ov = NULL;
 
 									TEST_OK_LABEL(done, retcode, Tcl_ListObjGetElements(interp, it_res, &oc, &ov));
@@ -1271,7 +1283,8 @@ static int foreach(Tcl_Interp* interp, int objc, Tcl_Obj *const objv[], enum col
 	}
 
 	for (i=0; i<state->iterators; i++) {
-		int				loops, j;
+		Tcl_Size		loops, count;
+		int				j;
 		enum json_types	type;
 		Tcl_Obj*		val;
 		Tcl_Obj*		varlist = objv[i*2];
@@ -1281,7 +1294,8 @@ static int foreach(Tcl_Interp* interp, int objc, Tcl_Obj *const objv[], enum col
 
 		replace_tclobj(&state->it[i].varlist, varlist);
 
-		TEST_OK_LABEL(done, retcode, Tcl_ListObjGetElements(interp, state->it[i].varlist, &state->it[i].var_c, &state->it[i].var_v));
+		TEST_OK_LABEL(done, retcode, Tcl_ListObjGetElements(interp, state->it[i].varlist, &count, &state->it[i].var_v));
+		state->it[i].var_c = count;
 		for (j=0; j < state->it[i].var_c; j++)
 			Tcl_IncrRefCount(state->it[i].var_v[j]);
 
@@ -1292,7 +1306,8 @@ static int foreach(Tcl_Interp* interp, int objc, Tcl_Obj *const objv[], enum col
 		switch (type) {
 			case JSON_ARRAY:
 				TEST_OK_LABEL(done, retcode,
-						Tcl_ListObjGetElements(interp, val, &state->it[i].data_c, &state->it[i].data_v));
+						Tcl_ListObjGetElements(interp, val, &count, &state->it[i].data_v));
+				state->it[i].data_c = count;
 				state->it[i].data_i = 0;
 				state->it[i].is_array = 1;
 				loops = (int)ceil(state->it[i].data_c / (double)state->it[i].var_c);
@@ -1341,7 +1356,8 @@ done:
 //}}}
 int json_pretty(Tcl_Interp* interp, Tcl_Obj* json, Tcl_Obj* indent, Tcl_Obj* pad, Tcl_DString* ds) //{{{
 {
-	int							pad_len, next_pad_len, count;
+	Tcl_Size					pad_len, next_pad_len;
+	int							count;
 	enum json_types				type;
 	const char*					pad_str;
 	const char*					next_pad_str;
@@ -1363,7 +1379,8 @@ int json_pretty(Tcl_Interp* interp, Tcl_Obj* json, Tcl_Obj* indent, Tcl_Obj* pad
 	switch (type) {
 		case JSON_OBJECT: //{{{
 			{
-				int				done, k_len, max=0, size;
+				int				done, max=0;
+				Tcl_Size		k_len, size;
 				Tcl_DictSearch	search;
 				Tcl_Obj*		k;
 				Tcl_Obj*		v;
@@ -1427,7 +1444,8 @@ int json_pretty(Tcl_Interp* interp, Tcl_Obj* json, Tcl_Obj* indent, Tcl_Obj* pad
 
 		case JSON_ARRAY: //{{{
 			{
-				int			i, oc;
+				int			i;
+				Tcl_Size	oc;
 				Tcl_Obj**	ov;
 
 				TEST_OK_LABEL(finally, retval, Tcl_ListObjGetElements(interp, val, &oc, &ov));
@@ -1469,7 +1487,8 @@ finally:
 //}}}
 static int json_pretty_dbg(Tcl_Interp* interp, Tcl_Obj* json, Tcl_Obj* indent, Tcl_Obj* pad, Tcl_DString* ds) //{{{
 {
-	int							indent_len, pad_len, next_pad_len, count;
+	Tcl_Size					indent_len, pad_len, next_pad_len;
+	int							count;
 	enum json_types				type;
 	const char*					pad_str;
 	const char*					next_pad_str;
@@ -1491,13 +1510,13 @@ static int json_pretty_dbg(Tcl_Interp* interp, Tcl_Obj* json, Tcl_Obj* indent, T
 
 	if (type == JSON_NULL) {
 		Tcl_Obj*	tmp = NULL;
-		replace_tclobj(&tmp, Tcl_ObjPrintf("(0x%lx[%d]/NULL)",
+		replace_tclobj(&tmp, Tcl_ObjPrintf("(0x%lx[%" TCL_SIZE_MODIFIER "d]/NULL)",
 						(unsigned long)(ptrdiff_t)json, json->refCount));
 		Tcl_DStringAppend(ds, Tcl_GetString(tmp), -1);
 		release_tclobj(&tmp);
 	} else {
 		Tcl_Obj*	tmp = NULL;
-		replace_tclobj(&tmp, Tcl_ObjPrintf("(0x%lx[%d]/0x%lx[%d] %s)",
+		replace_tclobj(&tmp, Tcl_ObjPrintf("(0x%lx[%" TCL_SIZE_MODIFIER "d]/0x%lx[%" TCL_SIZE_MODIFIER "d] %s)",
 						(unsigned long)(ptrdiff_t)json, json->refCount,
 						(unsigned long)(ptrdiff_t)val, val->refCount, val->typePtr ? val->typePtr->name : "pure string"));
 		Tcl_DStringAppend(ds, Tcl_GetString(tmp), -1);
@@ -1507,7 +1526,8 @@ static int json_pretty_dbg(Tcl_Interp* interp, Tcl_Obj* json, Tcl_Obj* indent, T
 	switch (type) {
 		case JSON_OBJECT: //{{{
 			{
-				int				done, k_len, max=0, size;
+				int				done, max=0;
+				Tcl_Size		k_len, size;
 				Tcl_DictSearch	search;
 				Tcl_Obj*		k;
 				Tcl_Obj*		v;
@@ -1571,7 +1591,8 @@ static int json_pretty_dbg(Tcl_Interp* interp, Tcl_Obj* json, Tcl_Obj* indent, T
 
 		case JSON_ARRAY: //{{{
 			{
-				int			i, oc;
+				int			i;
+				Tcl_Size	oc;
 				Tcl_Obj**	ov;
 
 				TEST_OK_LABEL(finally, retval, Tcl_ListObjGetElements(interp, val, &oc, &ov));
@@ -1693,7 +1714,8 @@ done:
 #endif
 static int prev_opcode(const struct template_cx *const cx) //{{{
 {
-	int			len, opcode;
+	Tcl_Size	len;
+	int			opcode;
 	Tcl_Obj*	last = NULL;
 
 	TEST_OK(Tcl_ListObjLength(cx->interp, cx->actions, &len));
@@ -1733,7 +1755,8 @@ static int emit_fetches(const struct template_cx *const cx) //{{{
 
 	TEST_OK(Tcl_DictObjFirst(cx->interp, cx->map, &search, &elem, &v, &done));
 	for (; !done; Tcl_DictObjNext(&search, &elem, &v, &done)) {
-		int				len, fetch_idx, types_search_done=0, used_fetch=0;
+		Tcl_Size		len;
+		int				fetch_idx, types_search_done=0, used_fetch=0;
 		Tcl_DictSearch	types_search;
 		Tcl_Obj*		type;
 		Tcl_Obj*		slot;
@@ -1770,7 +1793,7 @@ static int emit_fetches(const struct template_cx *const cx) //{{{
 				case JSON_DYN_LITERAL:
 					{
 						const char*		s;
-						int				len;
+						Tcl_Size		len;
 						enum json_types	type;
 
 						s = Tcl_GetStringFromObj(elem, &len);
@@ -1866,7 +1889,7 @@ static int remove_action(Tcl_Interp* interp, struct template_cx* cx, int idx) //
 {
 	idx *= 3;
 	if (idx < 0) {
-		int	len;
+		Tcl_Size	len;
 
 		TEST_OK(Tcl_ListObjLength(interp, cx->actions, &len));
 		idx += len;
@@ -1901,7 +1924,7 @@ static int template_actions(struct template_cx* cx, Tcl_Obj* template, enum acti
 				TEST_OK(emit_action(cx, PUSH_TARGET, Tcl_DuplicateObj(template), NULL));
 				TEST_OK(Tcl_DictObjFirst(interp, val, &search, &k, &v, &done));
 				for (; !done; Tcl_DictObjNext(&search, &k, &v, &done)) {
-					int				len;
+					Tcl_Size		len;
 					enum json_types	stype;
 					const char*		s = Tcl_GetStringFromObj(k, &len);
 
@@ -1947,7 +1970,8 @@ free_search:
 
 		case JSON_ARRAY:
 			{
-				int			i, oc;
+				int			i;
+				Tcl_Size	oc;
 				Tcl_Obj**	ov;
 				Tcl_Obj*	arr_elem = NULL;
 
@@ -2026,7 +2050,8 @@ int build_template_actions(Tcl_Interp* interp, Tcl_Obj* template, Tcl_Obj** acti
 		replace_tclobj(&cx.actions, Tcl_NewListObj(0, NULL));
 
 		{ // Find max cx stack depth
-			int			depth=0, actionc, i;
+			int			depth=0, i;
+			Tcl_Size	actionc;
 			Tcl_Obj**	actionv;
 
 			TEST_OK_LABEL(actions_done, retcode,
@@ -2100,7 +2125,8 @@ int apply_template_actions(Tcl_Interp* interp, Tcl_Obj* template, Tcl_Obj* actio
 	int			slotslen = 0;
 	int			retcode = TCL_OK;
 	Tcl_Obj**	actionv;
-	int			actionc, i;
+	Tcl_Size	actionc;
+	int			i;
 #define STATIC_STACK	8
 	Tcl_Obj*	stackstack[STATIC_STACK];
 	Tcl_Obj**	stack = NULL;
@@ -2177,7 +2203,7 @@ int apply_template_actions(Tcl_Interp* interp, Tcl_Obj* template, Tcl_Obj* actio
 					fill_slot(slots, slot, l->json_null);
 				} else {
 					const char*	str;
-					int			len;
+					Tcl_Size	len;
 					Tcl_Obj*	jval=NULL;
 
 					str = Tcl_GetStringFromObj(subst_val, &len);
@@ -2661,7 +2687,7 @@ endoptions:
 
 	if (objc >= argbase+2) {
 		const char*		s = NULL;
-		int				l;
+		Tcl_Size		l;
 
 		TEST_OK_LABEL(finally, code, resolve_path(interp, objv[argbase], objv+argbase+1, objc-(argbase+1), &target, 0, 1, def));
 		s = Tcl_GetStringFromObj(objv[objc-1], &l);
@@ -2882,7 +2908,7 @@ static int jsonString(ClientData cdata, Tcl_Interp* interp, int objc, Tcl_Obj *c
 #if DEDUP
 	struct interp_cx*	l = (struct interp_cx*)cdata;
 #endif
-	int					len;
+	Tcl_Size			len;
 	const char*			s;
 	enum json_types		type;
 	int					retval = TCL_OK;
@@ -2941,7 +2967,7 @@ finally:
 static int jsonObject(ClientData cdata, Tcl_Interp* interp, int objc, Tcl_Obj *const objv[]) //{{{
 {
 	int			retval = TCL_OK;
-	int			oc;
+	Tcl_Size	oc;
 	Tcl_Obj**	ov;
 	Tcl_Obj*	res = NULL;
 
@@ -2961,7 +2987,8 @@ finally:
 //}}}
 static int jsonArray(ClientData cdata, Tcl_Interp* interp, int objc, Tcl_Obj *const objv[]) //{{{
 {
-	int			i, ac, retval = TCL_OK;;
+	int			i, retval = TCL_OK;
+	Tcl_Size	ac;
 	Tcl_Obj**	av;
 	Tcl_Obj*	elem = NULL;
 	Tcl_Obj*	val = NULL;
@@ -3283,7 +3310,8 @@ static int jsonValid(ClientData cdata, Tcl_Interp* interp, int objc, Tcl_Obj *co
 			case O_EXTENSIONS:
 				{
 					Tcl_Obj**		ov;
-					int				oc, idx;
+					Tcl_Size		oc;
+					int				idx;
 
 					extensions = 0;		// An explicit list was supplied, reset the extensions
 
@@ -3700,13 +3728,13 @@ static int jsonNRObj(ClientData cdata, Tcl_Interp* interp, int objc, Tcl_Obj *co
 				unsigned long	addr;
 				Tcl_Obj*		obj = NULL;
 				const char*		s;
-				int				len;
+				Tcl_Size		len;
 
 				CHECK_ARGS(2, "addr");
 				TEST_OK(Tcl_GetLongFromObj(interp, objv[2], (long*)&addr));
 				obj = (Tcl_Obj*)addr;
 				s = Tcl_GetStringFromObj(obj, &len);
-				fprintf(stderr, "\tLeaked obj: %p[%d] len %d: \"%s\"\n", obj, obj->refCount, len, len < 256 ? s : "<too long>");
+				fprintf(stderr, "\tLeaked obj: %p[%" TCL_SIZE_MODIFIER "d] len %" TCL_SIZE_MODIFIER "d: \"%s\"\n", obj, obj->refCount, len, len < 256 ? s : "<too long>");
 
 				break;
 			}
@@ -3957,7 +3985,7 @@ DLLEXPORT int Rl_json_Init(Tcl_Interp* interp) //{{{
 	l->typeDouble = Tcl_GetObjType("double");
 	l->typeBignum = Tcl_GetObjType("bignum");
 	if (l->typeDict == NULL) THROW_ERROR("Can't retrieve objType for dict");
-	if (l->typeInt == NULL) THROW_ERROR("Can't retrieve objType for int");
+	//if (l->typeInt == NULL) THROW_ERROR("Can't retrieve objType for int");
 	if (l->typeDouble == NULL) THROW_ERROR("Can't retrieve objType for double");
 	//if (l->typeBignum == NULL) THROW_ERROR("Can't retrieve objType for bignum");
 

--- a/generic/rl_json.h
+++ b/generic/rl_json.h
@@ -63,13 +63,13 @@ enum cbor_mt {
 // Stubs exported API
 
 #ifdef USE_RL_JSON_STUBS
-EXTERN CONST char* Rl_jsonInitStubs _ANSI_ARGS_((Tcl_Interp* interp, CONST char* version, int exact));
+EXTERN CONST char* Rl_jsonInitStubs(Tcl_Interp* interp, CONST char* version, int exact);
 #else
 #	define Rl_jsonInitStubs(interp, version, exact) Tcl_PkgRequire(interp, "rl_json", version, exact)
 #endif
 #include "rl_jsonDecls.h"
 
-EXTERN int Rl_json_Init _ANSI_ARGS_((Tcl_Interp* interp));
-EXTERN int Rl_json_SafeInit _ANSI_ARGS_((Tcl_Interp* interp));
+EXTERN int Rl_json_Init(Tcl_Interp* interp);
+EXTERN int Rl_json_SafeInit(Tcl_Interp* interp);
 
 #endif

--- a/generic/rl_jsonInt.h
+++ b/generic/rl_jsonInt.h
@@ -281,14 +281,7 @@ void cbor_release(Tcl_Interp* interp);
 
 // Polyfill
 #ifndef Tcl_GetBytesFromObj
-//#define Tcl_GetBytesFromObj(interp, obj, lenptr) Tcl_GetByteArrayFromObj(obj, lenptr)
-static inline uint8_t* Tcl_GetBytesFromObj(Tcl_Interp* interp, Tcl_Obj* obj, size_t* lenPtr)
-{
-	int	len;
-	uint8_t*	bytes = Tcl_GetByteArrayFromObj(obj, &len);
-	*lenPtr = len;
-	return bytes;
-}
+#define Tcl_GetBytesFromObj(interp, obj, lenptr) Tcl_GetByteArrayFromObj(obj, lenptr)
 #endif
 
 #endif

--- a/generic/rl_jsonInt.h
+++ b/generic/rl_jsonInt.h
@@ -15,7 +15,10 @@
 #endif
 #include <endian.h>
 #include <tclTomMath.h>
+#if TIP445_SHIM
+#define Tcl_InitStringRep
 #include "tip445.h"
+#endif
 #include "names.h"
 
 #define CX_STACK_SIZE	6

--- a/pkgIndex.tcl.in
+++ b/pkgIndex.tcl.in
@@ -3,6 +3,6 @@
 #
 package ifneeded @PACKAGE_NAME@ @PACKAGE_VERSION@ [list apply {
 	dir {
-    	load [file join $dir @PKG_LIB_FILE@] @PACKAGE_NAME@
+    	load [file join $dir @PKG_LIB_FILE@]
 	}
 } $dir]

--- a/tests/all.tcl
+++ b/tests/all.tcl
@@ -222,6 +222,14 @@ if {[llength [info commands memory]] == 1} {
 	proc memtest args {tailcall ::tcltest::test {*}$args}
 }
 
+proc resultopts {regular {ensemble ""}} {
+    if {![namespace ensemble exists json]} {
+	return $regular
+    } else {
+	return $ensemble
+    }
+}
+
 set ::tcltest::testSingleFile false
 set ::tcltest::testsDirectory [file dir [info script]]
 

--- a/tests/extract.test
+++ b/tests/extract.test
@@ -1254,8 +1254,8 @@ test extract-70.1 {Path tail element isn't interpreted as a modifier - no need t
 #>>>
 
 # Coverage golf
-test extract-jsonExtract-1.1 {check args} -body {json extract} -returnCodes error -errorCode {TCL WRONGARGS} -result {wrong # args: should be "extract ?-default defaultValue? json_val ?path ...?"}
-test extract-jsonExtract-2.1 {check args} -body {json extract -default {"def"}} -returnCodes error -errorCode {TCL WRONGARGS} -result {wrong # args: should be "extract ?-default defaultValue? json_val ?path ...?"}
+test extract-jsonExtract-1.1 {check args} -body {json extract} -returnCodes error -errorCode {TCL WRONGARGS} -result [resultopts {wrong # args: should be "extract ?-default defaultValue? json_val ?path ...?"} {wrong # args: should be "json extract ?-default defaultValue? json_val ?path ...?"}]
+test extract-jsonExtract-2.1 {check args} -body {json extract -default {"def"}} -returnCodes error -errorCode {TCL WRONGARGS} -result [resultopts {wrong # args: should be "extract ?-default defaultValue? json_val ?path ...?"} {wrong # args: should be "json extract ?-default defaultValue? json_val ?path ...?"}]
 test extract-jsonExtract-3.1 {check args} -body {json extract -foo def} -returnCodes error -errorCode {TCL LOOKUP INDEX option -foo} -result {bad option "-foo": must be *} -match glob
 test extract-jsonExtract-4.1 {check args} -body {json extract -default} -returnCodes error -errorCode {TCL ARGUMENT MISSING} -result {missing argument to "-default"}
 test extract-jsonExtract-4.2 {check args} -body {json extract -default bad} -returnCodes error -errorCode {RL JSON PARSE {Illegal character} bad 0} -result {Error parsing JSON value: Illegal character at offset 0}

--- a/tests/get.test
+++ b/tests/get.test
@@ -1219,8 +1219,8 @@ test get-61.25 {Get a template point} -body { #<<<
 #>>>
 
 # Coverage golf
-test get-jsonGet-1.1 {check args} -body {json get} -returnCodes error -errorCode {TCL WRONGARGS} -result {wrong # args: should be "get ?-default defaultValue? json_val ?path ...?"}
-test get-jsonGet-2.1 {check args} -body {json get -default def} -returnCodes error -errorCode {TCL WRONGARGS} -result {wrong # args: should be "get ?-default defaultValue? json_val ?path ...?"}
+test get-jsonGet-1.1 {check args} -body {json get} -returnCodes error -errorCode {TCL WRONGARGS} -result [resultopts {wrong # args: should be "get ?-default defaultValue? json_val ?path ...?"} {wrong # args: should be "json get ?-default defaultValue? json_val ?path ...?"}]
+test get-jsonGet-2.1 {check args} -body {json get -default def} -returnCodes error -errorCode {TCL WRONGARGS} -result [resultopts {wrong # args: should be "get ?-default defaultValue? json_val ?path ...?"} {wrong # args: should be "json get ?-default defaultValue? json_val ?path ...?"}]
 test get-jsonGet-3.1 {check args} -body {json get -foo def} -returnCodes error -errorCode {TCL LOOKUP INDEX option -foo} -result {bad option "-foo": must be *} -match glob
 test get-jsonGet-4.1 {check args} -body {json get -default} -returnCodes error -errorCode {TCL ARGUMENT MISSING} -result {missing argument to "-default"}
 test get-jsonGet-5.1 {check args} -body {json get -- true} -result 1

--- a/tests/helpers.tcl
+++ b/tests/helpers.tcl
@@ -153,15 +153,9 @@ proc _compare_json {opts j1 j2 {path {}}} { #<<<
 }
 
 #>>>
-proc compare_json args { #<<<
-	parse_args $args {
-		-subset	{-default none}
-		j1		{}
-		j2		{}
-	} opts
-
+proc compare_json {j1 j2} { #<<<
 	try {
-		_compare_json $opts [dict get $opts j1] [dict get $opts j2]
+		_compare_json {} $j1 $j2
 	} trap {RL TEST JSON_MISMATCH} {errmsg options} {
 		return $errmsg
 	} on ok {} {

--- a/tests/length.test
+++ b/tests/length.test
@@ -13,7 +13,7 @@ test length-0.1 {too few args} -body { #<<<
 	list $code $r [dict get $o -errorcode]
 } -cleanup {
 	unset -nocomplain code r o
-} -result {1 {wrong # args: should be "length json_val ?path ...?"} {TCL WRONGARGS}}
+} -result [list 1 [resultopts {wrong # args: should be "length json_val ?path ...?"} {wrong # args: should be "json length json_val ?path ...?"}] {TCL WRONGARGS}]
 #>>>
 test length-1.1 {type: object, no path} -body { #<<<
 	json length {

--- a/tests/memory.test
+++ b/tests/memory.test
@@ -105,7 +105,7 @@ test memory-1.8 {memory leak with null parsing} -setup { #<<<
 #>>>
 test memory-2.1 {json foreach} -setup { #<<<
 	proc test_memory-2.1 {} {
-		set h	[open tests/foreach_data r]
+		set h	[open [file join [testsDirectory] foreach_data] r]
 		try {
 			chan configure $h -encoding utf-8
 			while {![set result [gets $h]; eof $h]} {

--- a/tests/new.test
+++ b/tests/new.test
@@ -34,7 +34,7 @@ test new-1.1.1 {Create an array from type-value pairs, syntax error in elem (too
 	json new array {*}$typevalues
 } -cleanup {
 	unset -nocomplain typevalues
-} -returnCodes error -result {wrong # args: should be "number value"}
+} -returnCodes error -result [resultopts {wrong # args: should be "number value"} {wrong # args: should be "json new value"}]
 #>>>
 
 test new-1.2 {Create an array from JSON values} -setup { #<<<
@@ -213,11 +213,11 @@ test new-6.9 {Create new bool: false} -body { #<<<
 #>>>
 test new-6.10.1 {Create new bool: value} -body { #<<<
 	json new bool
-} -returnCodes error -result {wrong # args: should be "boolean val"}
+} -returnCodes error -result [resultopts {wrong # args: should be "boolean val"} {wrong # args: should be "json new val"}]
 #>>>
 test new-6.10.2 {Create new bool: value} -body { #<<<
 	json new bool true false
-} -returnCodes error -result {wrong # args: should be "boolean val"}
+} -returnCodes error -result [resultopts {wrong # args: should be "boolean val"} {wrong # args: should be "json new val"}]
 #>>>
 test new-6.10.3 {Create new bool: value} -body { #<<<
 	json new bool true

--- a/tests/number.test
+++ b/tests/number.test
@@ -3,6 +3,8 @@ if {"::tcltest" ni [namespace children]} {
 	namespace import ::tcltest::*
 }
 
+testConstraint tcl8 [package vsatisfies [package present Tcl] 8]
+
 package require rl_json
 namespace path {::rl_json}
 
@@ -77,20 +79,20 @@ test number-1.13 {string} -body { #<<<
 } -result 42
 #>>>
 test number-1.14.1 {positive octal} -body { #<<<
-	set n	077
+	set n	0o77
 	expr {$n+0}	;# Convert to number type
 	list [json number $n] $n
 } -cleanup {
 	unset -nocomplain n
-} -result {63 077}
+} -result {63 0o77}
 #>>>
 test number-1.14.2 {negative octal} -body { #<<<
-	set n	-077
+	set n	-0o77
 	expr {$n+0}	;# Convert to number type
 	list [json number $n] $n
 } -cleanup {
 	unset -nocomplain n
-} -result {-63 -077}
+} -result {-63 -0o77}
 #>>>
 test number-1.15.1 {positive hex} -body { #<<<
 	set n	0xA0
@@ -236,12 +238,12 @@ test number-2.2 {Too many args} -body { #<<<
 #>>>
 test number-2.3 {json number, not a number} -body { #<<<
 	set code [catch {json number foo} r o]
-	list $code [regexp {^can't use non-numeric string( "foo")? as operand of "\+"$} $r] [dict get $o -errorcode]
+	list $code [regexp {^(can't|cannot) use non-numeric string( "foo")? as( right)? operand of "\+"$} $r] [dict get $o -errorcode]
 } -cleanup {
 	unset -nocomplain code r o
 } -match regexp -result {1 1 {ARITH DOMAIN {non-numeric string}}}
 #>>>
-test number-2.4 {json number, not a number: empty string} -body { #<<<
+test number-2.4 {json number, not a number: empty string} -constraints tcl8 -body { #<<<
 	set code [catch {json number ""} r o]
 	list $code [regexp {^can't use empty string( "")? as operand of "\+"$} $r] [dict get $o -errorcode]
 } -cleanup {

--- a/tests/pretty.test
+++ b/tests/pretty.test
@@ -50,7 +50,7 @@ test pretty-1.2 {Basic pretty-print, different indent} -body { #<<<
 #>>>
 test pretty-2.1 {too few args} -body { #<<<
 	json pretty
-} -returnCodes error -result {wrong # args: should be "pretty pretty ?-indent indent? json_val ?key ...?"}
+} -returnCodes error -result [resultopts {wrong # args: should be "pretty pretty ?-indent indent? json_val ?key ...?"} {wrong # args: should be "json pretty pretty ?-indent indent? json_val ?key ...?"}]
 #>>>
 test pretty-3.1 {path} -body { #<<<
 	json pretty {{"foo":null,"empty":{},"emptyarr":[],"hello, world":"bar","This is a much longer key":["str",123,123.4,true,false,null,{"inner": "obj"}]}} {This is a much longer key}
@@ -95,7 +95,7 @@ test debug-1.1 {Basic debug pretty-print} -body { #<<<
 # Coverage golf
 test pretty-jsonPretty-1.1 {} -body {json pretty -indent} -returnCodes error -result {missing argument to "-indent"} -errorCode {TCL ARGUMENT MISSING}
 test pretty-jsonPretty-2.1 {} -body {json pretty -- 1} -result 1
-test pretty-jsonPretty-3.1 {} -body {json pretty -indent {  }} -returnCodes error -result {wrong # args: should be "pretty ?-default defaultValue? json_val ?key ...?"} -errorCode {TCL WRONGARGS}
+test pretty-jsonPretty-3.1 {} -body {json pretty -indent {  }} -returnCodes error -result [resultopts {wrong # args: should be "pretty ?-default defaultValue? json_val ?key ...?"} {wrong # args: should be "json pretty ?-default defaultValue? json_val ?key ...?"}] -errorCode {TCL WRONGARGS}
 test pretty-jsonPretty-4.1 {} -body {json pretty bad} -returnCodes error -result {Error parsing JSON value: Illegal character at offset 0} -errorCode {RL JSON PARSE {Illegal character} bad 0}
 test pretty-jsonPretty-5.1 {} -body {json pretty -bad} -returnCodes error -result {bad option "-bad": must be *} -errorCode {TCL LOOKUP INDEX option -bad} -match glob
 

--- a/tests/pretty.test
+++ b/tests/pretty.test
@@ -4,8 +4,7 @@ if {"::tcltest" ni [namespace children]} {
 }
 
 package require rl_json
-package require parse_args
-namespace path {::rl_json ::parse_args}
+namespace path {::rl_json}
 
 test pretty-1.1 {Basic pretty-print} -body { #<<<
 	json pretty {{"foo":null,"empty":{},"emptyarr":[],"hello, world":"bar","This is a much longer key":["str",123,123.4,true,false,null,{"inner": "obj"}]}}

--- a/tests/set.test
+++ b/tests/set.test
@@ -4,8 +4,7 @@ if {"::tcltest" ni [namespace children]} {
 }
 
 package require rl_json
-package require parse_args
-namespace path {::rl_json ::parse_args}
+namespace path {::rl_json}
 
 source [file join [file dirname [info script]] helpers.tcl]
 

--- a/tests/unset.test
+++ b/tests/unset.test
@@ -4,8 +4,7 @@ if {"::tcltest" ni [namespace children]} {
 }
 
 package require rl_json
-package require parse_args
-namespace path {::rl_json ::parse_args}
+namespace path {::rl_json}
 
 source [file join [file dirname [info script]] helpers.tcl]
 

--- a/tests/valid.test
+++ b/tests/valid.test
@@ -10,43 +10,43 @@ test valid-0.1 {Too few args} -body { #<<<
 	list [catch {json valid} r o] $r [dict get $o -errorcode]
 } -cleanup {
 	unset -nocomplain r o
-} -result {1 {wrong # args: should be "valid ?-extensions extensionslist -details detailsvar? json_val"} {TCL WRONGARGS}}
+} -result [list 1 [resultopts {wrong # args: should be "valid ?-extensions extensionslist -details detailsvar? json_val"} {wrong # args: should be "json valid ?-extensions extensionslist -details detailsvar? json_val"}] {TCL WRONGARGS}]
 #>>>
 test valid-0.2 {Too few args: missing value for -extensions} -body { #<<<
 	list [catch {json valid -extensions true} r o] $r [dict get $o -errorcode]
 } -cleanup {
 	unset -nocomplain r o
-} -result {1 {wrong # args: should be "valid -extensions extensionslist json_val"} {TCL WRONGARGS}}
+} -result [list 1 [resultopts {wrong # args: should be "valid -extensions extensionslist json_val"} {wrong # args: should be "json valid -extensions extensionslist json_val"}] {TCL WRONGARGS}]
 #>>>
 test valid-0.3 {Too few args: missing value for -details} -body { #<<<
 	list [catch {json valid -details true} r o] $r [dict get $o -errorcode]
 } -cleanup {
 	unset -nocomplain r o
-} -result {1 {wrong # args: should be "valid -details detailsvar json_val"} {TCL WRONGARGS}}
+} -result [list 1 [resultopts {wrong # args: should be "valid -details detailsvar json_val"} {wrong # args: should be "json valid -details detailsvar json_val"}] {TCL WRONGARGS}]
 #>>>
 test valid-0.4 {Too few args: missing json_val folling -extensions} -body { #<<<
 	list [catch {json valid -extensions {}} r o] $r [dict get $o -errorcode]
 } -cleanup {
 	unset -nocomplain r o
-} -result {1 {wrong # args: should be "valid -extensions extensionslist json_val"} {TCL WRONGARGS}}
+} -result [list 1 [resultopts {wrong # args: should be "valid -extensions extensionslist json_val"} {wrong # args: should be "json valid -extensions extensionslist json_val"}] {TCL WRONGARGS}]
 #>>>
 test valid-0.5 {Too few args: missing json_val folling -details} -body { #<<<
 	list [catch {json valid -details d} r o] $r [dict get $o -errorcode]
 } -cleanup {
 	unset -nocomplain r o d
-} -result {1 {wrong # args: should be "valid -details detailsvar json_val"} {TCL WRONGARGS}}
+} -result [list 1 [resultopts {wrong # args: should be "valid -details detailsvar json_val"} {wrong # args: should be "json valid -details detailsvar json_val"}] {TCL WRONGARGS}]
 #>>>
 test valid-0.6 {Too few args: missing json_val folling -extensions -details} -body { #<<<
 	list [catch {json valid -extensions {} -details d} r o] $r [dict get $o -errorcode]
 } -cleanup {
 	unset -nocomplain r o d
-} -result {1 {wrong # args: should be "valid -extensions {} -details detailsvar json_val"} {TCL WRONGARGS}}
+} -result [list 1 [resultopts {wrong # args: should be "valid -extensions {} -details detailsvar json_val"} {wrong # args: should be "json valid -extensions {} -details detailsvar json_val"}] {TCL WRONGARGS}]
 #>>>
 test valid-0.7 {Too few args: missing json_val folling -details -extensions} -body { #<<<
 	list [catch {json valid -details d -extensions {}} r o] $r [dict get $o -errorcode]
 } -cleanup {
 	unset -nocomplain r o d
-} -result {1 {wrong # args: should be "valid -details d -extensions extensionslist json_val"} {TCL WRONGARGS}}
+} -result [list 1 [resultopts {wrong # args: should be "valid -details d -extensions extensionslist json_val"} {wrong # args: should be "json valid -details d -extensions extensionslist json_val"}] {TCL WRONGARGS}]
 #>>>
 test valid-0.8 {Too many args: no options} -body { #<<<
 	list [catch {json valid true false} r o] $r [dict get $o -errorcode]


### PR DESCRIPTION
I made changes necessary to be able to compile the library against Tcl 9.0, while still also being able to compile against Tcl 8.6. Additionally I adapted the test suite to account for the differences when the library is compiled with --enable-ensemble.